### PR TITLE
removed PropType for triggerText

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -6,12 +6,19 @@ var Collapsible = React.createClass({
   //Set validation for prop types
   propTypes: {
     transitionTime: React.PropTypes.number,
-    triggerTextWhenOpen: React.PropTypes.string,
     easing: React.PropTypes.string,
     open: React.PropTypes.bool,
     classParentString: React.PropTypes.string,
     accordionPosition: React.PropTypes.number,
-    handleTriggerClick: React.PropTypes.func
+    handleTriggerClick: React.PropTypes.func,
+    trigger: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element
+    ]),
+    triggerWhenOpen:React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element
+    ]),
   },
 
   //If no transition time or easing is passed then default to this
@@ -169,11 +176,11 @@ var Collapsible = React.createClass({
     var openClass = this.state.isClosed ? 'is-closed' : 'is-open';
 
     //If user wants different text when tray is open
-    var triggerText = (this.state.isClosed === false) && (this.props.triggerTextWhenOpen !== undefined) ? this.props.triggerTextWhenOpen : this.props.triggerText;
+    var trigger = (this.state.isClosed === false) && (this.props.triggerWhenOpen !== undefined) ? this.props.triggerWhenOpen : this.props.trigger;
 
     return(
       <div className={this.props.classParentString}>
-        <a href="#" className={this.props.classParentString + "__trigger" + ' ' + openClass} onClick={this.handleTriggerClick}>{triggerText}</a>
+        <span className={this.props.classParentString + "__trigger" + ' ' + openClass} onClick={this.handleTriggerClick}>{trigger}</span>
         <div className={this.props.classParentString + "__contentOuter" } ref="outer" style={dropdownStyle}>
           <div className={this.props.classParentString + "__contentInner"} ref="inner">
             {this.props.children}

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -6,7 +6,6 @@ var Collapsible = React.createClass({
   //Set validation for prop types
   propTypes: {
     transitionTime: React.PropTypes.number,
-    triggerText: React.PropTypes.string.isRequired,
     triggerTextWhenOpen: React.PropTypes.string,
     easing: React.PropTypes.string,
     open: React.PropTypes.bool,


### PR DESCRIPTION
It seems that an artificial limitation is being placed on the `triggerText` prop.

I find it very helpful to be able to pass in an object to this prop, as this allows us to pass it JSX. This should allow `react-collapsible` to be more flexible.

It appears that passing `triggerText` JSX is already working and rendering correctly, and at this point setting its PropType is only creating a console error.