### PR TITLE
add onOpen and onClose callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Unique key used to identify the `Collapse` instance when used in an accordion.
 ### `handleTriggerClick` | *function*
 Define this to override the click handler for the trigger link. Takes one parameter, which is `props.accordionPosition`.
 
+### `onOpen` | *function*
+Is called when the Collapsible is opening.
+
+### `onClose` | *function*
+Is called when the Collapsible is closing.
+
 ### `lazyRender` | *bool* | default: false
 Set this to true to postpone rendering of all of the content of the Collapsible until before it's opened for the first time
 

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -16,6 +16,8 @@ var Collapsible = React.createClass({
     contentInnerClassName: React.PropTypes.string,
     accordionPosition: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
     handleTriggerClick: React.PropTypes.func,
+    onOpen: React.PropTypes.func,
+    onClose: React.PropTypes.func,
     trigger: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element
@@ -55,6 +57,8 @@ var Collapsible = React.createClass({
       contentInnerClassName: '',
       className: '',
       triggerSibling: null,
+      onOpen: () => {},
+      onClose: () => {},
     };
   },
 
@@ -167,7 +171,7 @@ var Collapsible = React.createClass({
       shouldSwitchAutoOnNextCycle: true,
       height: this.refs.inner.offsetHeight,
       overflow: 'hidden',
-    });
+    }, this.props.onClose);
   },
 
   openCollapsible: function() {
@@ -176,7 +180,7 @@ var Collapsible = React.createClass({
       transition: 'height ' + this.props.transitionTime + 'ms ' + this.props.easing,
       isClosed: false,
       hasBeenOpened: true
-    });
+    }, this.props.onOpen);
   },
 
   makeResponsive: function() {


### PR DESCRIPTION
When you don't want to `handleTriggerClick`, but still like to know when your Collapsible is opening or closing.

Maybe my use case is too specific, but I think that it would be handy to have these.