### PR TITLE
Migrate to react v15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "scripts": {
     "build": "babel src/Collapsible.js > dist/Collapsible.js",
     "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const createReactClass = require('create-react-class');
 
-var Collapsible = React.createClass({
+var Collapsible = createReactClass({
 
   //Set validation for prop types
   propTypes: {

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,34 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 
 var Collapsible = React.createClass({
 
   //Set validation for prop types
   propTypes: {
-    transitionTime: React.PropTypes.number,
-    easing: React.PropTypes.string,
-    open: React.PropTypes.bool,
-    classParentString: React.PropTypes.string,
-    openedClassName: React.PropTypes.string,
-    triggerClassName: React.PropTypes.string,
-    triggerOpenedClassName: React.PropTypes.string,
-    contentOuterClassName: React.PropTypes.string,
-    contentInnerClassName: React.PropTypes.string,
-    accordionPosition: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-    handleTriggerClick: React.PropTypes.func,
-    onOpen: React.PropTypes.func,
-    onClose: React.PropTypes.func,
-    trigger: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element
+    transitionTime: PropTypes.number,
+    easing: PropTypes.string,
+    open: PropTypes.bool,
+    classParentString: PropTypes.string,
+    openedClassName: PropTypes.string,
+    triggerClassName: PropTypes.string,
+    triggerOpenedClassName: PropTypes.string,
+    contentOuterClassName: PropTypes.string,
+    contentInnerClassName: PropTypes.string,
+    accordionPosition: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    handleTriggerClick: PropTypes.func,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    trigger: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
     ]),
-    triggerWhenOpen:React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element
+    triggerWhenOpen:PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
     ]),
-    triggerDisabled: React.PropTypes.bool,
-    lazyRender: React.PropTypes.bool,
-    overflowWhenOpen: React.PropTypes.oneOf([
+    triggerDisabled: PropTypes.bool,
+    lazyRender: PropTypes.bool,
+    overflowWhenOpen: PropTypes.oneOf([
       'hidden',
       'visible',
       'auto',
@@ -37,7 +38,7 @@ var Collapsible = React.createClass({
       'initial',
       'unset',
     ]),
-    triggerSibling: React.PropTypes.element
+    triggerSibling: PropTypes.element
   },
 
   //If no transition time or easing is passed then default to this
@@ -240,13 +241,13 @@ var Collapsible = React.createClass({
     if (this.state.isClosed) {
       triggerClassName = triggerClassName + ' ' + this.props.triggerClassName;
     } else {
-      triggerClassName = triggerClassName + ' ' + this.props.triggerOpenedClassName;      
+      triggerClassName = triggerClassName + ' ' + this.props.triggerOpenedClassName;
     }
 
     return(
       <div className={this.props.classParentString + ' ' + (this.state.isClosed ? this.props.className : this.props.openedClassName)}>
         <span className={triggerClassName.trim()} onClick={this.handleTriggerClick}>{trigger}</span>
-        
+
         {this.renderNonClickableTriggerElement()}
 
         <div className={this.props.classParentString + "__contentOuter" + ' ' + this.props.contentOuterClassName } ref="outer" style={dropdownStyle}>


### PR DESCRIPTION
Hi.

In React v15.5.0, React.PropTypes and React.createClass became deprecate.
So I migrated to prop-types package and create-react-class package.

Ref: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html