### PR TITLE
Trigger element should be an 'a' tag for accessibility, keyboard functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Use this to overwrite the parent CSS class for the Collapsible component parts. 
 ### `openedClassName` | *string* 
 `.Collapsible` element (root) when open
 
+### `triggerElementTag` | *string* 
+`.Collapsible__trigger` change html element tag for the trigger, defaults to a tag
+
+### `nonClickableTriggerElementTag` | *string* 
+`.Collapsible__trigger` change html element tag for non clickable trigger, defaults to a tag
+
 ### `triggerClassName` | *string* 
 `.Collapsible__trigger` element (root) when closed
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ Use this to overwrite the parent CSS class for the Collapsible component parts. 
 `.Collapsible` element (root) when open
 
 ### `triggerElementTag` | *string* 
-`.Collapsible__trigger` change html element tag for the trigger, defaults to a tag
+`.Collapsible__trigger` change html element tag for the trigger, defaults to `<a>` tag
 
 ### `nonClickableTriggerElementTag` | *string* 
-`.Collapsible__trigger` change html element tag for non clickable trigger, defaults to a tag
+`.Collapsible__trigger` change html element tag for non clickable trigger, defaults to `<a>` tag
 
 ### `triggerClassName` | *string* 
 `.Collapsible__trigger` element (root) when closed

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -44,7 +44,9 @@ var oldCollapsible = createReactClass({
       'initial',
       'unset',
     ]),
-    triggerSibling: PropTypes.element
+    triggerSibling: PropTypes.element,
+    triggerElementTag: _react2.default.PropTypes.string,
+    nonClickableTriggerElementTag: _react2.default.PropTypes.string
   },
 
   //If no transition time or easing is passed then default to this
@@ -64,8 +66,9 @@ var oldCollapsible = createReactClass({
       contentInnerClassName: '',
       className: '',
       triggerSibling: null,
-      onOpen: () => {},
-      onClose: () => {},
+      triggerElementTag: 'a',
+      nonClickableTriggerElementTag: 'a'
+      
     };
   },
 
@@ -211,9 +214,11 @@ var oldCollapsible = createReactClass({
   },
 
   renderNonClickableTriggerElement: function () {
+    let nonClickableTriggerElementTag = this.props.nonClickableTriggerElementTag
+    
     if (this.props.triggerSibling) {
       return (
-        <span className={this.props.classParentString  + "__trigger-sibling"}>{this.props.triggerSibling}</span>
+        <nonClickableTriggerElementTag className={this.props.classParentString  + "__trigger-sibling"}>{this.props.triggerSibling}</nonClickableTriggerElementTag>
       )
     }
 
@@ -250,9 +255,11 @@ var oldCollapsible = createReactClass({
       triggerClassName = triggerClassName + ' ' + this.props.triggerOpenedClassName;
     }
 
+    let triggerElementTag = this.props.triggerElementTag
+
     return(
       <div className={this.props.classParentString + ' ' + (this.state.isClosed ? this.props.className : this.props.openedClassName)}>
-        <span className={triggerClassName.trim()} onClick={this.handleTriggerClick}>{trigger}</span>
+        <triggerElementTag className={triggerClassName.trim()} onClick={this.handleTriggerClick}>{trigger}</triggerElementTag>
 
         {this.renderNonClickableTriggerElement()}
 


### PR DESCRIPTION
The trigger tag is currently a span which prevents keyboard navigation. Changing the element to an `'a' ` with `href="#"` adds keyboard functionality so you can tab to a trigger and press enter to activate it. There's still a need to open the panel on focus, but this is a good start.

Since some people may still want to use span for whatever reason (don't recommend) the following props can be added with `'a'` as the default:
```
triggerElementTag: _react2.default.PropTypes.string,
nonClickableTriggerElementTag: _react2.default.PropTypes.string
```
This should be most of the scaffolding for an easy merge or at least enough to get a conversation going. I'll confess I kind of threw this together and I'm not sure if I did this correctly so feel free to yell at me if it's terrible 😎 