### PR TITLE
lazyRender functionallity

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -148,7 +148,10 @@ class Collapsible extends Component {
                   : this.props.trigger;
 
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
-    var children = (this.state.isClosed && !this.state.inTransition) ? null : this.props.children;
+    var children = this.props.lazyRender
+      && !this.state.hasBeenOpened
+      && this.state.isClosed
+      && !this.state.inTransition ? null : this.props.children;
 
     // Construct CSS classes strings
     const triggerClassString = `${this.props.classParentString}__trigger ${openClass} ${disabledClass} ${
@@ -162,17 +165,17 @@ class Collapsible extends Component {
 
     return(
       <div className={parentClassString.trim()}>
-        <span 
-          className={triggerClassString.trim()} 
+        <span
+          className={triggerClassString.trim()}
           onClick={this.handleTriggerClick}>
           {trigger}
         </span>
 
         {this.renderNonClickableTriggerElement()}
 
-        <div 
-          className={outerClassString.trim()} 
-          ref="outer" 
+        <div
+          className={outerClassString.trim()}
+          ref="outer"
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
         >


### PR DESCRIPTION
In the current source the prop lazyRender is never used.
Besides the unused prop, every time user opens or closes the collapsible, the component is mounting and unmounting the children:
```var children = (this.state.isClosed && !this.state.inTransition) ? null : this.props.children;```
Not a big problem if we're rendering a simple children. But if we have more complex components as a children -or components that trigger redux-actions (for example in a redux-form)- it may cause performance problems (an in any case unnecessary re mountings).