### PR TITLE
Add Typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,18 +2,27 @@ declare class Collapsible extends React.Component<CollapsibleProps> {}
 declare namespace Collapsible {}
 
 interface CollapsibleProps extends React.HTMLProps<Collapsible> {
-  trigger: string | React.ReactElement<any>
-  triggerWhenOpen?: string | React.ReactElement<any>
-  triggerDisabled?: false
   transitionTime?: number
+  transitionCloseTime?: number | null
+  triggerTagName?: string
   easing?: string
   open?: boolean
-  accordionPosition?: string
+  classParentString?: string
+  openedClassName?: string
+  triggerStyle?: null | Object
+  triggerClassName?: string
+  triggerOpenedClassName?: string
+  contentOuterClassName?: string
+  contentInnerClassName?: string
+  accordionPosition?: string | number
   handleTriggerClick?: (accordionPosition?: string | number) => void
   onOpen?: () => void
   onClose?: () => void
   onOpening?: () => void
   onClosing?: () => void
+  trigger: string | React.ReactElement<any>
+  triggerWhenOpen?: string | React.ReactElement<any>
+  triggerDisabled?: false
   lazyRender?: boolean
   overflowWhenOpen?:
     | 'hidden'
@@ -24,13 +33,8 @@ interface CollapsibleProps extends React.HTMLProps<Collapsible> {
     | 'initial'
     | 'unset'
   triggerSibling?: React.ReactElement<any>
-  classParentString?: string
   className?: string
-  openedClassName?: string
-  triggerClassName?: string
-  triggerOpenedClassName?: string
-  contentOuterClassName?: string
-  contentInnerClassName?: string
+  tabIndex?: null | number
 }
 
 declare module 'react-collapsible' {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+declare class Collapsible extends React.Component<CollapsibleProps> {}
+declare namespace Collapsible {}
+
+interface CollapsibleProps extends React.HTMLProps<Collapsible> {
+  trigger: string | React.ReactElement<any>
+  triggerWhenOpen?: string | React.ReactElement<any>
+  triggerDisabled?: false
+  transitionTime?: number
+  easing?: string
+  open?: boolean
+  accordionPosition?: string
+  handleTriggerClick?: (accordionPosition?: string | number) => void
+  onOpen?: () => void
+  onClose?: () => void
+  onOpening?: () => void
+  onClosing?: () => void
+  lazyRender?: boolean
+  overflowWhenOpen?:
+    | 'hidden'
+    | 'visible'
+    | 'auto'
+    | 'scroll'
+    | 'inherit'
+    | 'initial'
+    | 'unset'
+  triggerSibling?: React.ReactElement<any>
+  classParentString?: string
+  className?: string
+  openedClassName?: string
+  triggerClassName?: string
+  triggerOpenedClassName?: string
+  contentOuterClassName?: string
+  contentInnerClassName?: string
+}
+
+declare module 'react-collapsible' {
+  export default Collapsible
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "accordion"
   ],
   "main": "dist/Collapsible.js",
+  "types": "./index.d.ts",
   "author": "Glenn Flanagan <glenn@arctictiger.co.uk>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
# What does this PR do
Adds support for TypeScript by creating static types for the react component and all of its props

# Demo
Warnings on invalid prop usage:
![image](https://user-images.githubusercontent.com/1679438/31369358-c3aabce2-ad38-11e7-8fdc-8b4af7c156dd.png)


Warnings on wrong value type for a given prop:
![image](https://user-images.githubusercontent.com/1679438/31369389-f10bde82-ad38-11e7-8074-933376bfaa89.png)
