### PR TITLE
Enable the use of other elements different than 'span' as wrappers for the trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ With a little CSS becomes
 ### **trigger** | *string* or *React Element* | **required**
 The text or element to appear in the trigger link.
 
+### **triggerTagName** | *string* | default: span
+The tag name of the element wrapping the trigger text or element.
+
 ### **triggerWhenOpen** | *string* or *React Element*
 Optional trigger text or element to change to when the Collapsible is open.
 

--- a/example/_src/js/index.js
+++ b/example/_src/js/index.js
@@ -61,6 +61,11 @@ const App = () => {
         <img src="https://lorempixel.com/320/240?random=6" />
       </Collapsible>
 
+      <Collapsible trigger='You can set a custom trigger tag name.' triggerTagName='div'>
+        <p>Use the <code>`triggerTagName`</code> prop to set the trigger wrapping element.</p>
+        <p>Defaults to <code>span</code>.</p>
+      </Collapsible>
+
       <Collapsible trigger="You can customise the CSS a bit more too"
         triggerClassName="CustomTriggerCSS"
         triggerOpenedClassName="CustomTriggerCSS--open"

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -147,6 +147,9 @@ class Collapsible extends Component {
                   ? this.props.triggerWhenOpen
                   : this.props.trigger;
 
+    //If user wants a trigger wrapping element different than 'span'
+    const TriggerComponent = this.props.triggerComponent;
+
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
     var children = this.props.lazyRender
       && !this.state.hasBeenOpened
@@ -165,11 +168,11 @@ class Collapsible extends Component {
 
     return(
       <div className={parentClassString.trim()}>
-        <span
+        <TriggerComponent
           className={triggerClassString.trim()}
           onClick={this.handleTriggerClick}>
           {trigger}
-        </span>
+        </TriggerComponent>
 
         {this.renderNonClickableTriggerElement()}
 
@@ -193,6 +196,7 @@ class Collapsible extends Component {
 
 Collapsible.propTypes = {
   transitionTime: PropTypes.number,
+  triggerComponent: PropTypes.any,
   easing: PropTypes.string,
   open: PropTypes.bool,
   classParentString: PropTypes.string,
@@ -234,6 +238,7 @@ Collapsible.propTypes = {
 
 Collapsible.defaultProps = {
   transitionTime: 400,
+  triggerComponent: 'span',
   easing: 'linear',
   open: false,
   classParentString: 'Collapsible',

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -196,7 +196,7 @@ class Collapsible extends Component {
 
 Collapsible.propTypes = {
   transitionTime: PropTypes.number,
-  triggerComponent: PropTypes.any,
+  triggerComponent: PropTypes.string,
   easing: PropTypes.string,
   open: PropTypes.bool,
   classParentString: PropTypes.string,

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -147,8 +147,8 @@ class Collapsible extends Component {
                   ? this.props.triggerWhenOpen
                   : this.props.trigger;
 
-    //If user wants a trigger wrapping element different than 'span'
-    const TriggerComponent = this.props.triggerComponent;
+    // If user wants a trigger wrapping element different than 'span'
+    const TriggerElement = this.props.triggerTagName;
 
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
     var children = this.props.lazyRender
@@ -168,11 +168,11 @@ class Collapsible extends Component {
 
     return(
       <div className={parentClassString.trim()}>
-        <TriggerComponent
+        <TriggerElement
           className={triggerClassString.trim()}
           onClick={this.handleTriggerClick}>
           {trigger}
-        </TriggerComponent>
+        </TriggerElement>
 
         {this.renderNonClickableTriggerElement()}
 
@@ -196,7 +196,7 @@ class Collapsible extends Component {
 
 Collapsible.propTypes = {
   transitionTime: PropTypes.number,
-  triggerComponent: PropTypes.string,
+  triggerTagName: PropTypes.string,
   easing: PropTypes.string,
   open: PropTypes.bool,
   classParentString: PropTypes.string,
@@ -238,7 +238,7 @@ Collapsible.propTypes = {
 
 Collapsible.defaultProps = {
   transitionTime: 400,
-  triggerComponent: 'span',
+  triggerTagName: 'span',
   easing: 'linear',
   open: false,
   classParentString: 'Collapsible',


### PR DESCRIPTION
Add a new `triggerComponent` prop which enables the user to specify the HTML element to use as the wrapper for the trigger (defaults to `span`).
