### PR TITLE
Fix: Visibility issue on collapsed container.

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -142,7 +142,7 @@ class Collapsible extends Component {
       msTransition: this.state.transition,
       transition: this.state.transition,
       overflow: this.state.overflow,
-      visiblity: this.state.hideContainer ? 'hidden' : 'visible',
+      visibility: this.state.hideContainer ? 'hidden' : 'visible',
     }
 
     var openClass = this.state.isClosed ? 'is-closed' : 'is-open';

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -20,6 +20,7 @@ class Collapsible extends Component {
         hasBeenOpened: true,
         overflow: props.overflowWhenOpen,
         inTransition: false,
+        hideContainer: false,
       }
     } else {
       this.state = {
@@ -30,6 +31,7 @@ class Collapsible extends Component {
         hasBeenOpened: false,
         overflow: 'hidden',
         inTransition: false,
+        hideContainer: true,
       }
     }
   }
@@ -75,6 +77,7 @@ class Collapsible extends Component {
     this.setState({
       inTransition: true,
       shouldOpenOnNextCycle: true,
+      hideContainer: false,
     });
   }
 
@@ -127,7 +130,7 @@ class Collapsible extends Component {
       this.setState({ height: 'auto', overflow: this.props.overflowWhenOpen, inTransition: false });
       this.props.onOpen();
     } else {
-      this.setState({ inTransition: false });
+      this.setState({ inTransition: false, hideContainer: true });
       this.props.onClose();
     }
   }
@@ -139,6 +142,7 @@ class Collapsible extends Component {
       msTransition: this.state.transition,
       transition: this.state.transition,
       overflow: this.state.overflow,
+      visiblity: this.state.hideContainer ? 'hidden' : 'visible',
     }
 
     var openClass = this.state.isClosed ? 'is-closed' : 'is-open';


### PR DESCRIPTION
I noticed that on a collapsed outer container, the one with `overflow: 'hidden'` and `height: 0`, the elements can still be visible under some circumstances. Since this should never happen, I added a `visibility: 'hidden'` property to the outer container style.