### PR TITLE
Use callback instead of string refs.

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -9,6 +9,7 @@ class Collapsible extends Component {
     this.handleTriggerClick = this.handleTriggerClick.bind(this);
     this.handleTransitionEnd = this.handleTransitionEnd.bind(this);
     this.continueOpenCollapsible = this.continueOpenCollapsible.bind(this);
+    this.setInnerRef = this.setInnerRef.bind(this);
 
     // Defaults the dropdown to be closed
     if (props.open) {
@@ -65,7 +66,7 @@ class Collapsible extends Component {
   closeCollapsible() {
     this.setState({
       shouldSwitchAutoOnNextCycle: true,
-      height: this.refs.inner.offsetHeight,
+      height: this.innerRef.offsetHeight,
       transition: `height ${this.props.transitionCloseTime ?
         this.props.transitionCloseTime : this.props.transitionTime}ms ${this.props.easing}`,
       inTransition: true,
@@ -81,7 +82,7 @@ class Collapsible extends Component {
 
   continueOpenCollapsible() {
     this.setState({
-      height: this.refs.inner.offsetHeight,
+      height: this.innerRef.offsetHeight,
       transition: `height ${this.props.transitionTime}ms ${this.props.easing}`,
       isClosed: false,
       hasBeenOpened: true,
@@ -131,6 +132,10 @@ class Collapsible extends Component {
       this.setState({ inTransition: false });
       this.props.onClose();
     }
+  }
+
+  setInnerRef(ref) {
+    this.innerRef = ref
   }
 
   render() {
@@ -190,13 +195,12 @@ class Collapsible extends Component {
 
         <div
           className={outerClassString.trim()}
-          ref="outer"
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
         >
           <div
             className={innerClassString.trim()}
-            ref="inner"
+            ref={this.setInnerRef}
           >
             {children}
           </div>


### PR DESCRIPTION
This PR replaces string refs with callback refs.

[See manual](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs):

> If you worked with React before, you might be familiar with an older API where the ref attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have some issues, are considered legacy, and **are likely to be removed in one of the future releases.**

As the library still supports React versions <16.3, I did not replace it with the even newer [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs).

Also it seems that the outer ref was not in use, so I removed it.