### PR TITLE
Removed 'null' from tabIndex type def.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ interface CollapsibleProps extends React.HTMLProps<Collapsible> {
     | 'unset'
   triggerSibling?: React.ReactElement<any>
   className?: string
-  tabIndex?: null | number
+  tabIndex?: number
 }
 
 declare module 'react-collapsible' {


### PR DESCRIPTION
Was causing typescript build errors.