### PR TITLE
fix classProps to allow for a default className, closed, and open cla…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ Supported by [Browserstack](https://www.browserstack.com).
 ![Browserstack Logo](example/img/browserstack-logo.png "Browserstack")
 
 ---
+
+# Version 3.0.0
+
+## V3 Props
+
+| Prop | Description | Default |
+|---|---|---|
+|**`className`**|The class name for the root component applied in all states (open & closed). |`''`|
+|**`classNameOpen`**|The class name for the root component applied when open. |`''`|
+|**`classNameClosed`**|The class name for the root component applied closed. |`''`|
+
 ## Migrating from v1.x to v2.x
+
 Version 2 is 100% API complete to version 1. However, there is a breaking change in the `onOpen` and `onClose` callbacks. These methods now fire at the end of the collapsing animation. There is also the addition of `onOpening` and `onClosing` callbacks which fire at the beginning of the animation.
 
 To migrate to v2 from v1 simply change the `onOpen` prop to `onOpening` and `onClose` to `onClosing`.

--- a/example/src/js/index.js
+++ b/example/src/js/index.js
@@ -1,19 +1,25 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import Collapsible from '../../../src/Collapsible'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Collapsible from '../../../src/Collapsible';
 
-import '../sass/main.scss'
+import '../sass/main.scss';
 
 const triggerSiblingExample = () => (
   <div className="Collapsible__custom-sibling">
     This is a sibling to the trigger which wont cause the Collapsible to open!
   </div>
-)
+);
 
 const App = () => {
   return (
     <div>
-      <Collapsible className='classNameDefault' classNameOpen='classNameOpen' classNameClosed='classNameClosed' tabIndex={0} trigger="Start here">
+      <Collapsible
+        className="classNameDefault"
+        classNameOpen="classNameOpen"
+        classNameClosed="classNameClosed"
+        tabIndex={0}
+        trigger="Start here"
+      >
         <p>This is the collapsible content. It can be any element or React component you like.</p>
         <p>It can even be another Collapsible component. Check out the next section!</p>
       </Collapsible>
@@ -164,7 +170,7 @@ const App = () => {
         </p>
       </Collapsible>
     </div>
-  )
-}
+  );
+};
 
-ReactDOM.render(<App />, document.querySelector('#root'))
+ReactDOM.render(<App />, document.querySelector('#root'));

--- a/example/src/js/index.js
+++ b/example/src/js/index.js
@@ -1,15 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import Collapsible from '../../../src/Collapsible';
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Collapsible from '../../../src/Collapsible'
 
-import '../sass/main.scss';
+import '../sass/main.scss'
 
-const triggerSiblingExample = () => <div className="Collapsible__custom-sibling">This is a sibling to the trigger which wont cause the Collapsible to open!</div>;
+const triggerSiblingExample = () => (
+  <div className="Collapsible__custom-sibling">
+    This is a sibling to the trigger which wont cause the Collapsible to open!
+  </div>
+)
 
 const App = () => {
   return (
     <div>
-      <Collapsible tabIndex={0} trigger="Start here">
+      <Collapsible className='classNameDefault' classNameOpen='classNameOpen' classNameClosed='classNameClosed' tabIndex={0} trigger="Start here">
         <p>This is the collapsible content. It can be any element or React component you like.</p>
         <p>It can even be another Collapsible component. Check out the next section!</p>
       </Collapsible>
@@ -19,40 +23,94 @@ const App = () => {
         <p>See; you can nest as many Collapsible components as you like.</p>
 
         <Collapsible trigger="Mmmmm, it's all cosy nested here">
-          <p>And there's no limit to how many levels deep you go. Or how many you have on the same level.</p>
+          <p>
+            And there's no limit to how many levels deep you go. Or how many you have on the same
+            level.
+          </p>
 
           <Collapsible trigger="This is just another Collapsible">
-            <p>It just keeps going and going! Well, actually we've stopped here. But that's only because I'm running out of things to type.</p>
+            <p>
+              It just keeps going and going! Well, actually we've stopped here. But that's only
+              because I'm running out of things to type.
+            </p>
           </Collapsible>
           <Collapsible trigger="But this one is open by default!" open={true}>
             <p>And would you look at that! This one is open by default. Sexy huh!?</p>
-            <p>You can pass the prop of open=&#123;true&#125; which will make the Collapsible open by default.</p>
+            <p>
+              You can pass the prop of open=&#123;true&#125; which will make the Collapsible open by
+              default.
+            </p>
           </Collapsible>
-          <Collapsible trigger="That's not all. Check out the speed of this one" transitionTime={100}>
+          <Collapsible
+            trigger="That's not all. Check out the speed of this one"
+            transitionTime={100}
+          >
             <p>Whoosh! That was fast right?</p>
-            <p>You can control the time it takes to animate (transition) by passing the prop transitionTime a value in milliseconds. This one was set to transitionTime=&#123;100&#125;</p>
+            <p>
+              You can control the time it takes to animate (transition) by passing the prop
+              transitionTime a value in milliseconds. This one was set to
+              transitionTime=&#123;100&#125;
+            </p>
           </Collapsible>
-
         </Collapsible>
       </Collapsible>
 
-      <Collapsible transitionTime={400} trigger="This one will blow your mind." easing={'cubic-bezier(0.175, 0.885, 0.32, 2.275)'}>
-        <p>Well maybe not. But did you see that little wiggle at the end. That is using a CSS cubic-beizer for the easing!</p>
-        <p>You can pass any string into the prop easing that you would declare in a CSS transition-timing-function. This means you have complete control over how that Collapsible appears.</p>
+      <Collapsible
+        transitionTime={400}
+        trigger="This one will blow your mind."
+        easing={'cubic-bezier(0.175, 0.885, 0.32, 2.275)'}
+      >
+        <p>
+          Well maybe not. But did you see that little wiggle at the end. That is using a CSS
+          cubic-beizer for the easing!
+        </p>
+        <p>
+          You can pass any string into the prop easing that you would declare in a CSS
+          transition-timing-function. This means you have complete control over how that Collapsible
+          appears.
+        </p>
       </Collapsible>
 
-      <Collapsible transitionTime={400} trigger="Oh and did I mention that I'm responsive?" triggerWhenOpen="Plus you can change the trigger text when I'm open too">
-        <p>That's correct. This collapsible section will animate to the height it needs to and then set it's height back to auto.</p>
-        <p>This means that no matter what width you stretch that viewport to, the Collapsible it will respond to it.</p>
+      <Collapsible
+        transitionTime={400}
+        trigger="Oh and did I mention that I'm responsive?"
+        triggerWhenOpen="Plus you can change the trigger text when I'm open too"
+      >
+        <p>
+          That's correct. This collapsible section will animate to the height it needs to and then
+          set it's height back to auto.
+        </p>
+        <p>
+          This means that no matter what width you stretch that viewport to, the Collapsible it will
+          respond to it.
+        </p>
         <p>And no matter what height the content within it is, it will change height too.</p>
         <h2>CSS Styles</h2>
-        <p>All of the style of the Collapsible (apart from the overflow and transition) are controlled by your own CSS too.</p>
-        <p>By default the top-level CSS class is Collapsible, but you have control over this too so you can easily add it into your own project. Neato!</p>
-        <p>So by setting the prop of classParentString=&#123;"MyNamespacedClass"&#125; then the top-level class will become MyNamespacedClass.</p>
+        <p>
+          All of the style of the Collapsible (apart from the overflow and transition) are
+          controlled by your own CSS too.
+        </p>
+        <p>
+          By default the top-level CSS class is Collapsible, but you have control over this too so
+          you can easily add it into your own project. Neato!
+        </p>
+        <p>
+          So by setting the prop of classParentString=&#123;"MyNamespacedClass"&#125; then the
+          top-level class will become MyNamespacedClass.
+        </p>
       </Collapsible>
 
-      <Collapsible lazyRender transitionTime={600} trigger="What happens if there's a shed-load of content?" easing={'cubic-bezier(0.175, 0.885, 0.32, 2.275)'} overflowWhenOpen="visible">
-        <p>Add the prop of <strong style={{ fontWeight: 'bold' }}>lazyRender</strong> and the content will only be rendered when the trigger is pressed</p>
+      <Collapsible
+        lazyRender
+        transitionTime={600}
+        trigger="What happens if there's a shed-load of content?"
+        easing={'cubic-bezier(0.175, 0.885, 0.32, 2.275)'}
+        overflowWhenOpen="visible"
+      >
+        <p>
+          Add the prop of <strong style={{ fontWeight: 'bold' }}>lazyRender</strong> and the content
+          will only be rendered when the trigger is pressed
+        </p>
         <img src="https://lorempixel.com/320/240?random=1" />
         <img src="https://lorempixel.com/320/240?random=2" />
         <img src="https://lorempixel.com/320/240?random=3" />
@@ -61,12 +119,17 @@ const App = () => {
         <img src="https://lorempixel.com/320/240?random=6" />
       </Collapsible>
 
-      <Collapsible trigger='You can set a custom trigger tag name.' triggerTagName='div'>
-        <p>Use the <code>`triggerTagName`</code> prop to set the trigger wrapping element.</p>
-        <p>Defaults to <code>span</code>.</p>
+      <Collapsible trigger="You can set a custom trigger tag name." triggerTagName="div">
+        <p>
+          Use the <code>`triggerTagName`</code> prop to set the trigger wrapping element.
+        </p>
+        <p>
+          Defaults to <code>span</code>.
+        </p>
       </Collapsible>
 
-      <Collapsible trigger="You can customise the CSS a bit more too"
+      <Collapsible
+        trigger="You can customise the CSS a bit more too"
         triggerClassName="CustomTriggerCSS"
         triggerOpenedClassName="CustomTriggerCSS--open"
         contentOuterClassName="CustomOuterContentCSS"
@@ -77,19 +140,31 @@ const App = () => {
 
       <Collapsible trigger="You can disable them programatically too" open triggerDisabled>
         <p>This one has it's trigger disabled in the open position. Nifty.</p>
-        <p>You also get the <strong>is-disabled</strong> CSS class so you can style it.</p>
+        <p>
+          You also get the <strong>is-disabled</strong> CSS class so you can style it.
+        </p>
       </Collapsible>
 
-      <Collapsible trigger="You can have siblings to the trigger too which won't trigger the Collapsible" triggerSibling={triggerSiblingExample}>
+      <Collapsible
+        trigger="You can have siblings to the trigger too which won't trigger the Collapsible"
+        triggerSibling={triggerSiblingExample}
+      >
         <p>This one has it's trigger disabled in the open position. Nifty.</p>
-        <p>You also get the <strong>is-disabled</strong> CSS class so you can style it.</p>
+        <p>
+          You also get the <strong>is-disabled</strong> CSS class so you can style it.
+        </p>
       </Collapsible>
 
-      <Collapsible trigger={"Add a triggerStyle Prop to add style directly to the trigger"} triggerStyle={{background: '#2196f3'}}>
-        <p>Adds a <code>style</code> attribute to the <code>span</code> trigger.</p>
+      <Collapsible
+        trigger={'Add a triggerStyle Prop to add style directly to the trigger'}
+        triggerStyle={{ background: '#2196f3' }}
+      >
+        <p>
+          Adds a <code>style</code> attribute to the <code>span</code> trigger.
+        </p>
       </Collapsible>
     </div>
-  );
-};
+  )
+}
 
-ReactDOM.render(<App />, document.querySelector('#root'));
+ReactDOM.render(<App />, document.querySelector('#root'))

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 export default class Collapsible extends Component {
   constructor(props) {
     super(props)
@@ -30,29 +29,30 @@ export default class Collapsible extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if(this.state.shouldOpenOnNextCycle){
-      this.continueOpenCollapsible();
+    if (this.state.shouldOpenOnNextCycle) {
+      this.continueOpenCollapsible()
     }
 
     if (prevState.height === 'auto' && this.state.shouldSwitchAutoOnNextCycle === true) {
-      window.setTimeout(() => { // Set small timeout to ensure a true re-render
+      window.setTimeout(() => {
+        // Set small timeout to ensure a true re-render
         this.setState({
           height: 0,
           overflow: 'hidden',
           isClosed: true,
           shouldSwitchAutoOnNextCycle: false,
-        });
-      }, 50);
+        })
+      }, 50)
     }
 
     // If there has been a change in the open prop (controlled by accordion)
     if (prevProps.open !== this.props.open) {
-      if(this.props.open === true) {
-        this.openCollapsible();
-        this.props.onOpening();
+      if (this.props.open === true) {
+        this.openCollapsible()
+        this.props.onOpening()
       } else {
-        this.closeCollapsible();
-        this.props.onClosing();
+        this.closeCollapsible()
+        this.props.onClosing()
       }
     }
   }
@@ -61,17 +61,18 @@ export default class Collapsible extends Component {
     this.setState({
       shouldSwitchAutoOnNextCycle: true,
       height: this.innerRef.scrollHeight,
-      transition: `height ${this.props.transitionCloseTime ?
-        this.props.transitionCloseTime : this.props.transitionTime}ms ${this.props.easing}`,
+      transition: `height ${
+        this.props.transitionCloseTime ? this.props.transitionCloseTime : this.props.transitionTime
+      }ms ${this.props.easing}`,
       inTransition: true,
-    });
+    })
   }
 
   openCollapsible() {
     this.setState({
       inTransition: true,
       shouldOpenOnNextCycle: true,
-    });
+    })
   }
 
   continueOpenCollapsible = () => {
@@ -82,25 +83,25 @@ export default class Collapsible extends Component {
       hasBeenOpened: true,
       inTransition: true,
       shouldOpenOnNextCycle: false,
-    });
+    })
   }
 
-  handleTriggerClick = (event) => {
-    event.preventDefault();
+  handleTriggerClick = event => {
+    event.preventDefault()
 
     if (this.props.triggerDisabled) {
       return
     }
 
     if (this.props.handleTriggerClick) {
-      this.props.handleTriggerClick(this.props.accordionPosition);
+      this.props.handleTriggerClick(this.props.accordionPosition)
     } else {
       if (this.state.isClosed === true) {
-        this.openCollapsible();
-        this.props.onOpening();
+        this.openCollapsible()
+        this.props.onOpening()
       } else {
-        this.closeCollapsible();
-        this.props.onClosing();
+        this.closeCollapsible()
+        this.props.onClosing()
       }
     }
   }
@@ -108,23 +109,25 @@ export default class Collapsible extends Component {
   renderNonClickableTriggerElement() {
     if (this.props.triggerSibling && typeof this.props.triggerSibling === 'string') {
       return (
-        <span className={`${this.props.classParentString}__trigger-sibling`}>{this.props.triggerSibling}</span>
+        <span className={`${this.props.classParentString}__trigger-sibling`}>
+          {this.props.triggerSibling}
+        </span>
       )
-    } else if(this.props.triggerSibling) {
+    } else if (this.props.triggerSibling) {
       return <this.props.triggerSibling />
     }
 
-    return null;
+    return null
   }
 
   handleTransitionEnd = () => {
     // Switch to height auto to make the container responsive
     if (!this.state.isClosed) {
-      this.setState({ height: 'auto', overflow: this.props.overflowWhenOpen, inTransition: false });
-      this.props.onOpen();
+      this.setState({ height: 'auto', overflow: this.props.overflowWhenOpen, inTransition: false })
+      this.props.onOpen()
     } else {
-      this.setState({ inTransition: false });
-      this.props.onClose();
+      this.setState({ inTransition: false })
+      this.props.onClose()
     }
   }
 
@@ -137,46 +140,61 @@ export default class Collapsible extends Component {
       overflow: this.state.overflow,
     }
 
-    var openClass = this.state.isClosed ? 'is-closed' : 'is-open';
-    var disabledClass = this.props.triggerDisabled ? 'is-disabled' : '';
+    var toggleClassName = this.state.isClosed ? 'is-closed' : 'is-open'
+    var disabledClass = this.props.triggerDisabled ? 'is-disabled' : ''
 
-    //If user wants different text when tray is open
-    var trigger = (this.state.isClosed === false) && (this.props.triggerWhenOpen !== undefined)
-                  ? this.props.triggerWhenOpen
-                  : this.props.trigger;
+    // If user wants different text when tray is open
+    var trigger =
+      this.state.isClosed === false && this.props.triggerWhenOpen !== undefined
+        ? this.props.triggerWhenOpen
+        : this.props.trigger
 
     // If user wants a trigger wrapping element different than 'span'
-    const TriggerElement = this.props.triggerTagName;
+    const TriggerElement = this.props.triggerTagName
 
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
-    var children = this.props.lazyRender
-      && !this.state.hasBeenOpened
-      && this.state.isClosed
-      && !this.state.inTransition ? null : this.props.children;
+    var children =
+      this.props.lazyRender &&
+      !this.state.hasBeenOpened &&
+      this.state.isClosed &&
+      !this.state.inTransition
+        ? null
+        : this.props.children
+
+    const className = this.props.className
+    const openedClassName = this.props.classNameOpen || ''
+    const closedClassName = this.props.classNameClosed || ''
 
     // Construct CSS classes strings
-    const triggerClassString = `${this.props.classParentString}__trigger ${openClass} ${disabledClass} ${
+    const triggerClassString = `${
+      this.props.classParentString
+    }__trigger ${toggleClassName} ${disabledClass} ${
       this.state.isClosed ? this.props.triggerClassName : this.props.triggerOpenedClassName
-    }`;
-    const parentClassString = `${this.props.classParentString} ${
-      this.state.isClosed ? this.props.className : this.props.openedClassName
-    }`;
-    const outerClassString = `${this.props.classParentString}__contentOuter ${this.props.contentOuterClassName}`;
-    const innerClassString = `${this.props.classParentString}__contentInner ${this.props.contentInnerClassName}`;
+    }`
+    const outerClassString = `${this.props.classParentString}__contentOuter ${
+      this.props.contentOuterClassName
+    }`
+    const innerClassString = `${this.props.classParentString}__contentInner ${
+      this.props.contentInnerClassName
+    }`
 
-    return(
-      <div className={parentClassString.trim()}>
+    return (
+      <div
+        className={`${this.props.classParentString} ${className} ${
+          this.state.isClosed ? closedClassName : openedClassName
+        }`}
+      >
         <TriggerElement
           className={triggerClassString.trim()}
           onClick={this.handleTriggerClick}
           style={this.props.triggerStyle && this.props.triggerStyle}
-          onKeyPress={(event) => {
-            const { key } = event;
-              if (key === ' ' || key === 'Enter') {
-                this.handleTriggerClick(event);
-              }
-            }}
-            tabIndex={this.props.tabIndex && this.props.tabIndex}
+          onKeyPress={event => {
+            const { key } = event
+            if (key === ' ' || key === 'Enter') {
+              this.handleTriggerClick(event)
+            }
+          }}
+          tabIndex={this.props.tabIndex && this.props.tabIndex}
         >
           {trigger}
         </TriggerElement>
@@ -187,48 +205,32 @@ export default class Collapsible extends Component {
           className={outerClassString.trim()}
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
-          ref={(ref) => this.innerRef = ref}
+          ref={ref => (this.innerRef = ref)}
         >
-          <div
-            className={innerClassString.trim()}
-          >
-            {children}
-          </div>
+          <div className={innerClassString.trim()}>{children}</div>
         </div>
       </div>
-    );
+    )
   }
 }
 
 Collapsible.propTypes = {
-  transitionTime: PropTypes.number,
-  transitionCloseTime: PropTypes.number,
-  triggerTagName: PropTypes.string,
-  easing: PropTypes.string,
-  open: PropTypes.bool,
-  classParentString: PropTypes.string,
-  openedClassName: PropTypes.string,
-  triggerStyle: PropTypes.object,
-  triggerClassName: PropTypes.string,
-  triggerOpenedClassName: PropTypes.string,
-  contentOuterClassName: PropTypes.string,
-  contentInnerClassName: PropTypes.string,
   accordionPosition: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  className: PropTypes.string,
+  classNameClosed: PropTypes.string,
+  classNameOpen: PropTypes.string,
+  classParentString: PropTypes.string,
+  contentInnerClassName: PropTypes.string,
+  contentOuterClassName: PropTypes.string,
+  easing: PropTypes.string,
   handleTriggerClick: PropTypes.func,
-  onOpen: PropTypes.func,
-  onClose: PropTypes.func,
-  onOpening: PropTypes.func,
-  onClosing: PropTypes.func,
-  trigger: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element
-  ]),
-  triggerWhenOpen:PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element
-  ]),
-  triggerDisabled: PropTypes.bool,
   lazyRender: PropTypes.bool,
+  onClose: PropTypes.func,
+  onClosing: PropTypes.func,
+  onOpen: PropTypes.func,
+  onOpening: PropTypes.func,
+  open: PropTypes.bool,
+  openedClassName: PropTypes.string,
   overflowWhenOpen: PropTypes.oneOf([
     'hidden',
     'visible',
@@ -238,34 +240,42 @@ Collapsible.propTypes = {
     'initial',
     'unset',
   ]),
-  triggerSibling: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.func,
-  ]),
   tabIndex: PropTypes.number,
+  transitionCloseTime: PropTypes.number,
+  transitionTime: PropTypes.number,
+  trigger: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  triggerClassName: PropTypes.string,
+  triggerDisabled: PropTypes.bool,
+  triggerOpenedClassName: PropTypes.string,
+  triggerSibling: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+  triggerStyle: PropTypes.object,
+  triggerTagName: PropTypes.string,
+  triggerWhenOpen: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 }
 
 Collapsible.defaultProps = {
-  transitionTime: 400,
-  transitionCloseTime: null,
-  triggerTagName: 'span',
-  easing: 'linear',
-  open: false,
-  classParentString: 'Collapsible',
-  triggerDisabled: false,
-  lazyRender: false,
-  overflowWhenOpen: 'hidden',
-  openedClassName: '',
-  triggerStyle: null,
-  triggerClassName: '',
-  triggerOpenedClassName: '',
-  contentOuterClassName: '',
-  contentInnerClassName: '',
   className: '',
-  triggerSibling: null,
-  onOpen: () => {},
+  classNameClosed: '',
+  classNameOpen: '',
+  classParentString: 'Collapsible',
+  contentInnerClassName: '',
+  contentOuterClassName: '',
+  easing: 'linear',
+  lazyRender: false,
   onClose: () => {},
-  onOpening: () => {},
   onClosing: () => {},
+  onOpen: () => {},
+  onOpening: () => {},
+  open: false,
+  openedClassName: '',
+  overflowWhenOpen: 'hidden',
   tabIndex: null,
-};
+  transitionCloseTime: null,
+  transitionTime: 400,
+  triggerClassName: '',
+  triggerDisabled: false,
+  triggerOpenedClassName: '',
+  triggerSibling: null,
+  triggerStyle: null,
+  triggerTagName: 'span',
+}

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -162,8 +162,8 @@ export default class Collapsible extends Component {
         : this.props.children
 
     const className = this.props.className
-    const openedClassName = this.props.classNameOpen || ''
-    const closedClassName = this.props.classNameClosed || ''
+    const openedClassName = this.props.classNameOpen
+    const closedClassName = this.props.classNameClosed
 
     // Construct CSS classes strings
     const triggerClassString = `${

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 export default class Collapsible extends Component {
   constructor(props) {
-    super(props)
+    super(props);
 
     // Defaults the dropdown to be closed
     if (props.open) {
@@ -14,7 +14,7 @@ export default class Collapsible extends Component {
         hasBeenOpened: true,
         overflow: props.overflowWhenOpen,
         inTransition: false,
-      }
+      };
     } else {
       this.state = {
         isClosed: true,
@@ -24,13 +24,13 @@ export default class Collapsible extends Component {
         hasBeenOpened: false,
         overflow: 'hidden',
         inTransition: false,
-      }
+      };
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state.shouldOpenOnNextCycle) {
-      this.continueOpenCollapsible()
+      this.continueOpenCollapsible();
     }
 
     if (prevState.height === 'auto' && this.state.shouldSwitchAutoOnNextCycle === true) {
@@ -41,18 +41,18 @@ export default class Collapsible extends Component {
           overflow: 'hidden',
           isClosed: true,
           shouldSwitchAutoOnNextCycle: false,
-        })
-      }, 50)
+        });
+      }, 50);
     }
 
     // If there has been a change in the open prop (controlled by accordion)
     if (prevProps.open !== this.props.open) {
       if (this.props.open === true) {
-        this.openCollapsible()
-        this.props.onOpening()
+        this.openCollapsible();
+        this.props.onOpening();
       } else {
-        this.closeCollapsible()
-        this.props.onClosing()
+        this.closeCollapsible();
+        this.props.onClosing();
       }
     }
   }
@@ -65,14 +65,14 @@ export default class Collapsible extends Component {
         this.props.transitionCloseTime ? this.props.transitionCloseTime : this.props.transitionTime
       }ms ${this.props.easing}`,
       inTransition: true,
-    })
+    });
   }
 
   openCollapsible() {
     this.setState({
       inTransition: true,
       shouldOpenOnNextCycle: true,
-    })
+    });
   }
 
   continueOpenCollapsible = () => {
@@ -83,28 +83,28 @@ export default class Collapsible extends Component {
       hasBeenOpened: true,
       inTransition: true,
       shouldOpenOnNextCycle: false,
-    })
-  }
+    });
+  };
 
   handleTriggerClick = event => {
-    event.preventDefault()
+    event.preventDefault();
 
     if (this.props.triggerDisabled) {
-      return
+      return;
     }
 
     if (this.props.handleTriggerClick) {
-      this.props.handleTriggerClick(this.props.accordionPosition)
+      this.props.handleTriggerClick(this.props.accordionPosition);
     } else {
       if (this.state.isClosed === true) {
-        this.openCollapsible()
-        this.props.onOpening()
+        this.openCollapsible();
+        this.props.onOpening();
       } else {
-        this.closeCollapsible()
-        this.props.onClosing()
+        this.closeCollapsible();
+        this.props.onClosing();
       }
     }
-  }
+  };
 
   renderNonClickableTriggerElement() {
     if (this.props.triggerSibling && typeof this.props.triggerSibling === 'string') {
@@ -112,24 +112,24 @@ export default class Collapsible extends Component {
         <span className={`${this.props.classParentString}__trigger-sibling`}>
           {this.props.triggerSibling}
         </span>
-      )
+      );
     } else if (this.props.triggerSibling) {
-      return <this.props.triggerSibling />
+      return <this.props.triggerSibling />;
     }
 
-    return null
+    return null;
   }
 
   handleTransitionEnd = () => {
     // Switch to height auto to make the container responsive
     if (!this.state.isClosed) {
-      this.setState({ height: 'auto', overflow: this.props.overflowWhenOpen, inTransition: false })
-      this.props.onOpen()
+      this.setState({ height: 'auto', overflow: this.props.overflowWhenOpen, inTransition: false });
+      this.props.onOpen();
     } else {
-      this.setState({ inTransition: false })
-      this.props.onClose()
+      this.setState({ inTransition: false });
+      this.props.onClose();
     }
-  }
+  };
 
   render() {
     var dropdownStyle = {
@@ -138,19 +138,19 @@ export default class Collapsible extends Component {
       msTransition: this.state.transition,
       transition: this.state.transition,
       overflow: this.state.overflow,
-    }
+    };
 
-    var toggleClassName = this.state.isClosed ? 'is-closed' : 'is-open'
-    var disabledClass = this.props.triggerDisabled ? 'is-disabled' : ''
+    var toggleClassName = this.state.isClosed ? 'is-closed' : 'is-open';
+    var disabledClass = this.props.triggerDisabled ? 'is-disabled' : '';
 
     // If user wants different text when tray is open
     var trigger =
       this.state.isClosed === false && this.props.triggerWhenOpen !== undefined
         ? this.props.triggerWhenOpen
-        : this.props.trigger
+        : this.props.trigger;
 
     // If user wants a trigger wrapping element different than 'span'
-    const TriggerElement = this.props.triggerTagName
+    const TriggerElement = this.props.triggerTagName;
 
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
     var children =
@@ -159,24 +159,24 @@ export default class Collapsible extends Component {
       this.state.isClosed &&
       !this.state.inTransition
         ? null
-        : this.props.children
+        : this.props.children;
 
-    const className = this.props.className
-    const openedClassName = this.props.classNameOpen
-    const closedClassName = this.props.classNameClosed
+    const className = this.props.className;
+    const openedClassName = this.props.classNameOpen;
+    const closedClassName = this.props.classNameClosed;
 
     // Construct CSS classes strings
     const triggerClassString = `${
       this.props.classParentString
     }__trigger ${toggleClassName} ${disabledClass} ${
       this.state.isClosed ? this.props.triggerClassName : this.props.triggerOpenedClassName
-    }`
+    }`;
     const outerClassString = `${this.props.classParentString}__contentOuter ${
       this.props.contentOuterClassName
-    }`
+    }`;
     const innerClassString = `${this.props.classParentString}__contentInner ${
       this.props.contentInnerClassName
-    }`
+    }`;
 
     return (
       <div
@@ -189,9 +189,9 @@ export default class Collapsible extends Component {
           onClick={this.handleTriggerClick}
           style={this.props.triggerStyle && this.props.triggerStyle}
           onKeyPress={event => {
-            const { key } = event
+            const { key } = event;
             if (key === ' ' || key === 'Enter') {
-              this.handleTriggerClick(event)
+              this.handleTriggerClick(event);
             }
           }}
           tabIndex={this.props.tabIndex && this.props.tabIndex}
@@ -210,7 +210,7 @@ export default class Collapsible extends Component {
           <div className={innerClassString.trim()}>{children}</div>
         </div>
       </div>
-    )
+    );
   }
 }
 
@@ -251,7 +251,7 @@ Collapsible.propTypes = {
   triggerStyle: PropTypes.object,
   triggerTagName: PropTypes.string,
   triggerWhenOpen: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-}
+};
 
 Collapsible.defaultProps = {
   className: '',
@@ -278,4 +278,4 @@ Collapsible.defaultProps = {
   triggerSibling: null,
   triggerStyle: null,
   triggerTagName: 'span',
-}
+};


### PR DESCRIPTION
Apologies about this large looking commit. It is waiting for #112 as that added eslint.

This closes #87 by having 3 new props for classNames. One for the default state and two for open/closed states.
See source [here](https://github.com/glennflanagan/react-collapsible/compare/release/3.0.0...feature/fixed-class-name-props-for-any-states?expand=1#diff-d6bdac83848e1771954455043583685fR164)

Misc stuff:
• Sorted PropTypes and defaultProps alphabetically
• Updated README.md for v3.0.0

```js
const className = this.props.className
const openedClassName = this.props.classNameOpen
const closedClassName = this.props.classNameClosed
```