### PR TITLE
feat: export typescript interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare class Collapsible extends React.Component<CollapsibleProps> {}
 declare namespace Collapsible {}
 
-interface CollapsibleProps extends React.HTMLProps<Collapsible> {
+export interface CollapsibleProps extends React.HTMLProps<Collapsible> {
   transitionTime?: number
   transitionCloseTime?: number | null
   triggerTagName?: string


### PR DESCRIPTION
Add export to `CollapsibleProps` in case of user want to extend his/her own interface from it.