### PR TITLE
Feature/pass props to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ With a little CSS becomes
 ### **contentContainerTagName** | *string* | default: `div`
 Tag Name for the Collapsible Root Element.
 
+### **containerElementProps** | *object*
+Pass props (or attributes) to the top div element. Useful for inserting `id`.
+
 ### **trigger** | *string* or *React Element* | **required**
 The text or element to appear in the trigger link.
 

--- a/example/_src/js/index.js
+++ b/example/_src/js/index.js
@@ -75,7 +75,7 @@ const App = () => {
         <p>This is the collapsible content. It can be any element or React component you like.</p>
       </Collapsible>
 
-      <Collapsible trigger="You can disable them programatically too" open triggerDisabled>
+      <Collapsible trigger="You can disable them programmatically too" open triggerDisabled>
         <p>This one has it's trigger disabled in the open position. Nifty.</p>
         <p>You also get the <strong>is-disabled</strong> CSS class so you can style it.</p>
       </Collapsible>

--- a/example/_src/js/index.js
+++ b/example/_src/js/index.js
@@ -88,6 +88,20 @@ const App = () => {
       <Collapsible trigger={"Add a triggerStyle Prop to add style directly to the trigger"} triggerStyle={{background: '#2196f3'}}>
         <p>Adds a <code>style</code> attribute to the <code>span</code> trigger.</p>
       </Collapsible>
+      <Collapsible trigger="Pass properties to element" containerElementProps={{ id: 'my-cool-identifier', lang: 'en' }} triggerStyle={{ background: '#6821f3' }}>
+        <p>Some element attributes (<strong>id & lang</strong>) have been passed as properties using <strong>containerElementProps</strong>.</p>
+        <div style={{ display: 'grid' }}>
+          <img src="https://lorempixel.com/320/240?random=1" />
+          <img src="https://lorempixel.com/320/240?random=2" />
+          <img src="https://lorempixel.com/320/240?random=3" />
+          <img src="https://lorempixel.com/320/240?random=4" />
+          <img src="https://lorempixel.com/320/240?random=5" />
+          <img src="https://lorempixel.com/320/240?random=6" />
+        </div>
+        <div style={{ padding: '50px' }}>
+          <button onClick={ () => document.getElementById('my-cool-identifier').scrollIntoView() }>Scroll to my id</button>
+        </div>
+      </Collapsible>
     </div>
   );
 };

--- a/example/_src/js/index.js
+++ b/example/_src/js/index.js
@@ -88,7 +88,7 @@ const App = () => {
       <Collapsible trigger={"Add a triggerStyle Prop to add style directly to the trigger"} triggerStyle={{background: '#2196f3'}}>
         <p>Adds a <code>style</code> attribute to the <code>span</code> trigger.</p>
       </Collapsible>
-      <Collapsible trigger="Pass properties to element" containerElementProps={{ id: 'my-cool-identifier', lang: 'en' }} triggerStyle={{ background: '#6821f3' }}>
+      <Collapsible trigger="Pass properties to top element" containerElementProps={{ id: 'my-cool-identifier', lang: 'en' }} triggerStyle={{ background: '#6821f3' }}>
         <p>Some element attributes (<strong>id & lang</strong>) have been passed as properties using <strong>containerElementProps</strong>.</p>
         <div style={{ display: 'grid' }}>
           <img src="https://lorempixel.com/320/240?random=1" />

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -185,7 +185,7 @@ class Collapsible extends Component {
     const innerClassString = `${this.props.classParentString}__contentInner ${this.props.contentInnerClassName}`;
 
     return(
-      <ContentContainerElement className={parentClassString.trim()}>
+      <ContentContainerElement className={parentClassString.trim()} {...this.props.containerElementProps} >
         <TriggerElement
           className={triggerClassString.trim()}
           onClick={this.handleTriggerClick}
@@ -226,6 +226,7 @@ Collapsible.propTypes = {
   triggerTagName: PropTypes.string,
   easing: PropTypes.string,
   open: PropTypes.bool,
+  containerElementProps: PropTypes.object,
   classParentString: PropTypes.string,
   openedClassName: PropTypes.string,
   triggerStyle: PropTypes.object,


### PR DESCRIPTION
### Minimal feature implementation
- Added `containerElementProps` prop using spreader
- Example given
- README updated
- spelling corrected

resolves #123