### PR TITLE
Fix: Button Trigger + Space Bar Bug

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -196,7 +196,7 @@ class Collapsible extends Component {
           style={this.props.triggerStyle && this.props.triggerStyle}
           onKeyPress={(event) => {
             const { key } = event;
-            if (key === ' ' || key === 'Enter') {
+            if ((key === ' ' && this.props.triggerTagName.toLowerCase() !== 'button') || key === 'Enter') {
               this.handleTriggerClick(event);
             }
           }}

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -196,7 +196,7 @@ class Collapsible extends Component {
           style={this.props.triggerStyle && this.props.triggerStyle}
           onKeyPress={(event) => {
             const { key } = event;
-            if ((key === ' ' && this.props.triggerTagName.toLowerCase() !== 'button') || key === 'Enter') {
+            if (key === ' ' || key === 'Enter') {
               this.handleTriggerClick(event);
             }
           }}


### PR DESCRIPTION
Fixes https://github.com/glennflanagan/react-collapsible/issues/155

When the trigger element is a button, `onClick` gets fired when the space bar is pressed, so `handleTriggerClick` doesn't need to be called in the `onKeyPress` event in that scenario