### PR TITLE
Add render prop for when you want the content to be aware of the collapsible state

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Is called when the Collapsible close trigger is clicked. Like onClosing except i
 ### **lazyRender** | *bool* | default: false
 Set this to true to postpone rendering of all of the content of the Collapsible until before it's opened for the first time
 
+### **render** | *function* | default: null
+A `render` function can be used instead of children. this function will get `isOpened` is `inTransition` props, useful for adding aria-hidden attributes or pausing media.
+
+This overrides the children prop.
+
 ### **overflowWhenOpen** | *enum* | default: 'hidden'
 The CSS overflow property once the Collapsible is open. This can be any one of the valid CSS values of `'hidden'`, `'visible'`, `'auto'`, `'scroll'`, `'inherit'`, `'initial'`, or `'unset'`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ export interface CollapsibleProps extends React.HTMLProps<Collapsible> {
   triggerWhenOpen?: string | React.ReactElement<any>;
   triggerDisabled?: boolean;
   lazyRender?: boolean;
+  render?: () => React.ReactElement<any>;
   overflowWhenOpen?:
     | "hidden"
     | "visible"

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -217,6 +217,8 @@ class Collapsible extends Component {
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
           ref={this.setInnerRef}
+          aria-hidden={this.state.isClosed}
+          hidden={this.state.isClosed && !this.state.inTransition}
         >
           <div
             className={innerClassString.trim()}

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -126,7 +126,7 @@ class Collapsible extends Component {
       return (
         <span className={`${this.props.classParentString}__trigger-sibling`}>{this.props.triggerSibling}</span>
       )
-    } else if (this.props.triggerSibling && typeof this.props.triggerSibling === 'function') {    
+    } else if (this.props.triggerSibling && typeof this.props.triggerSibling === 'function') {
       return this.props.triggerSibling();
     } else if (this.props.triggerSibling) {
       return <this.props.triggerSibling />
@@ -177,10 +177,10 @@ class Collapsible extends Component {
     const TriggerElement = this.props.triggerTagName;
 
     // Don't render children until the first opening of the Collapsible if lazy rendering is enabled
-    var children = this.props.lazyRender
+    var shouldNotRender = this.props.lazyRender
       && !this.state.hasBeenOpened
       && this.state.isClosed
-      && !this.state.inTransition ? null : this.props.children;
+      && !this.state.inTransition;
 
     // Construct CSS classes strings
     const triggerClassString = `${this.props.classParentString}__trigger ${openClass} ${disabledClass} ${
@@ -192,6 +192,7 @@ class Collapsible extends Component {
     const outerClassString = `${this.props.classParentString}__contentOuter ${this.props.contentOuterClassName}`;
     const innerClassString = `${this.props.classParentString}__contentInner ${this.props.contentInnerClassName}`;
 
+    const { children, render } = this.props
     return (
       <ContentContainerElement className={parentClassString.trim()} {...this.props.containerElementProps} >
         <TriggerElement
@@ -217,13 +218,17 @@ class Collapsible extends Component {
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
           ref={this.setInnerRef}
-          aria-hidden={this.state.isClosed}
-          hidden={this.state.isClosed && !this.state.inTransition}
         >
           <div
             className={innerClassString.trim()}
           >
-            {children}
+            {
+              shouldNotRender
+                ? null
+                : render
+                  ? render({ isClosed: this.state.isClosed, inTransition: this.state.inTransition })
+                  : children
+            }
           </div>
         </div>
       </ContentContainerElement>
@@ -264,6 +269,7 @@ Collapsible.propTypes = {
   ]),
   triggerDisabled: PropTypes.bool,
   lazyRender: PropTypes.bool,
+  render: PropTypes.func,
   overflowWhenOpen: PropTypes.oneOf([
     'hidden',
     'visible',
@@ -290,6 +296,7 @@ Collapsible.defaultProps = {
   classParentString: 'Collapsible',
   triggerDisabled: false,
   lazyRender: false,
+  render: null,
   overflowWhenOpen: 'hidden',
   openedClassName: '',
   triggerStyle: null,


### PR DESCRIPTION
I'de like to add `aria-hidden="true"` to the content are when it's closed (or closing) and perhaps also the hidden attribute when it's fully closed
```jsx
aria-hidden={this.state.isClosed}
hidden={this.state.isClosed && !this.state.inTransition}
```
What needs to get done to get something like this merged?
Should this go behind a prop or wait for a major version?

You can test this out in existing projects by replacing the react-collapsible package for:
```json
"react-collapsible-pr-166": "https://github.com/arye-dov-eidelman/react-collapsible.git#3dfbbf13ef4db82e40d9b206acfefe683b0469d8",
```
