### PR TITLE
add two missing keys in CollapsibleProps typescript interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,11 +8,13 @@ export interface CollapsibleProps extends React.HTMLProps<Collapsible> {
   triggerTagName?: string;
   easing?: string;
   open?: boolean;
+  containerElementProps?: object;
   classParentString?: string;
   openedClassName?: string;
   triggerStyle?: null | React.CSSProperties;
   triggerClassName?: string;
   triggerOpenedClassName?: string;
+  triggerElementProps?: object;
   contentOuterClassName?: string;
   contentInnerClassName?: string;
   accordionPosition?: string | number;


### PR DESCRIPTION
Adds two missing keys in CollapsibleProps' Typescript interface
