### PR TITLE
Change contentHiddenWhenClosed to set the css visibility instead of the html hidden property

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -199,4 +199,28 @@ describe('<Collapsible />', () => {
       expect(wrapper.props().open).toBe(false);
     });
   });
+  
+  describe('contentHiddenWhenClosed prop', () => {
+    it('does not hide the content when open', () => {
+      const wrapper = mount(
+        <Collapsible trigger="Hello World" open={true} contentHiddenWhenClosed>
+          <input/>
+        </Collapsible>
+      );
+      const inputElement = wrapper.find('input').getDOMNode();
+      const styles = getComputedStyle(inputElement);
+      expect(styles.visibility).not.toEqual('hidden');
+    });
+
+    it('hides the content when closed', () => {
+      const wrapper = mount(
+        <Collapsible trigger="Hello World" open={false} contentHiddenWhenClosed>
+          <input/>
+        </Collapsible>
+      );
+      const inputElement = wrapper.find('input').getDOMNode();
+      const styles = getComputedStyle(inputElement);
+      expect(styles.visibility).toEqual('hidden');
+    });
+  });
 });

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -177,6 +177,9 @@ class Collapsible extends Component {
       transition: this.state.transition,
       overflow: this.state.overflow,
     };
+    if (this.props.contentHiddenWhenClosed && this.state.isClosed && !this.state.inTransition) {
+      dropdownStyle.visibility = 'hidden';
+    }
 
     var openClass = this.state.isClosed ? 'is-closed' : 'is-open';
     var disabledClass = this.props.triggerDisabled ? 'is-disabled' : '';
@@ -253,11 +256,6 @@ class Collapsible extends Component {
           style={dropdownStyle}
           onTransitionEnd={this.handleTransitionEnd}
           ref={this.setInnerRef}
-          hidden={
-            this.props.contentHiddenWhenClosed &&
-            this.state.isClosed &&
-            !this.state.inTransition
-          }
         >
           <div className={innerClassString.trim()}>{children}</div>
         </div>


### PR DESCRIPTION
This stops it from interfering with the content's scrollHeight fixing #194.

I've also added two tests for this prop.
