### PR TITLE
Fix triggerSibling typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export interface CollapsibleProps extends React.HTMLProps<Collapsible> {
     | "initial"
     | "unset";
   contentHiddenWhenClosed?: boolean;
-  triggerSibling?: React.ReactElement<any>;
+  triggerSibling?: string | React.ReactElement<any>;
   className?: string;
   tabIndex?: number;
   contentContainerTagName?: string;

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -315,7 +315,7 @@ Collapsible.propTypes = {
     'unset',
   ]),
   contentHiddenWhenClosed: PropTypes.bool,
-  triggerSibling: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+  triggerSibling: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   tabIndex: PropTypes.number,
   contentContainerTagName: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),


### PR DESCRIPTION
Property `triggerSibling` had wrong typing. Should be same as `trigger`.