### PR TITLE
Keep component name after minify in build

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -278,6 +278,7 @@ class Collapsible extends Component {
   }
 }
 
+Collapsible.displayName = 'Collapsible'
 Collapsible.propTypes = {
   transitionTime: PropTypes.number,
   transitionCloseTime: PropTypes.number,


### PR DESCRIPTION
After 2.8.3, The component name will be minified by webpack in build.
Therefore, Current version of react-collapsible has following problems.

This PR will resolve it.

### 1. Component name in React Developer Tools is minified
Until 2.8.0, The component name is `Collapsible`, but current component name is `s` after 2.8.3.
IMO, This name may be changed unexpectedly due to changes of webpack behavior and variable name in minification.

![image](https://user-images.githubusercontent.com/191358/221812367-1e43fb7b-a7a9-4bc2-8dd0-3b02dc78b317.png)

### 2. Can't find component in unittest with enzyme
After 2.8.3, following test code will fail. Because `component.find('Collapsible')` can't find component.

```
expect(component.find('Collapsible').prop('open')).toBeTruthy()
```